### PR TITLE
Add checks when file is not under the client workspace

### DIFF
--- a/lib/atom-perforce.js
+++ b/lib/atom-perforce.js
@@ -152,7 +152,7 @@ atomPerforce.exports = {
             // call p4 info to make sure perforce is available
             return execP4Command('info', { cwd: openedBufferFilePath })
             .then(function(p4Info) {
-                if(!p4Info['clientUnknown.']) {
+                if(!p4Info['clientUnknown.'] && openedBufferFilePath.startsWith(p4Info.clientRoot)) {
                     return execP4Command('edit', { cwd: openedBufferFilePath, files: [openedBufferFilename] })
                     .then(function(result) {
                         // p4 edit returns a 0 exit code even if the file is already opened
@@ -201,26 +201,26 @@ atomPerforce.exports = {
             // call p4 info to make sure perforce is available
             return execP4Command('info', { cwd: openedBufferFilePath })
             .then(function(p4Info) {
-                if(!p4Info['clientUnknown.']) {
-                return execP4Command('add', { cwd: openedBufferFilePath, files: [openedBufferFilename] })
-                .then(function(result) {
-                    // for some unfortunate reason, p4 add <existing file> returns a 0 exit code
-                    if((/can't add existing file/).test(result)) {
-                        atom.notifications.addWarning('Perforce: file already exists', { detail: result, dismissable: true });
-                    }
-                    else if((/already opened|currently opened/).test(result)) {
-                        atom.notifications.addWarning('Perforce: file already opened', { detail: result, dismissable: true });
-                    }
-                    else {
-                        atom.notifications.addSuccess('Perforce: file opened for add', { detail: result });
-                        console.log(result);
-                    }
-                })
-                .catch(function(err) {
-                    atom.notifications.addError('Perforce: failed to open for add', { detail: err.message, dismissable: true });
-                        console.error(err);
-                        return false;
-                    });
+                if(!p4Info['clientUnknown.'] && openedBufferFilePath.startsWith(p4Info.clientRoot)) {
+                    return execP4Command('add', { cwd: openedBufferFilePath, files: [openedBufferFilename] })
+                    .then(function(result) {
+                        // for some unfortunate reason, p4 add <existing file> returns a 0 exit code
+                        if((/can't add existing file/).test(result)) {
+                            atom.notifications.addWarning('Perforce: file already exists', { detail: result, dismissable: true });
+                        }
+                        else if((/already opened|currently opened/).test(result)) {
+                            atom.notifications.addWarning('Perforce: file already opened', { detail: result, dismissable: true });
+                        }
+                        else {
+                            atom.notifications.addSuccess('Perforce: file opened for add', { detail: result });
+                            console.log(result);
+                        }
+                    })
+                    .catch(function(err) {
+                        atom.notifications.addError('Perforce: failed to open for add', { detail: err.message, dismissable: true });
+                            console.error(err);
+                            return false;
+                        });
                 }
                 else {
                     console.info(openedBufferFilePath + ' is outside any known perforce workspace');
@@ -304,8 +304,10 @@ atomPerforce.exports = {
                 promises.push(synced);
                 // call p4 info to make sure perforce is available
                 execP4Command('info', { cwd: dir })
-                .then(function() {
-                    return execP4Command('sync', { cwd: dir, files: ['./...'] });
+                .then(function(p4Info) {
+                    if (!p4Info['clientUnknown.'] && dir.startsWith(p4Info.clientRoot)) {
+                        return execP4Command('sync', { cwd: dir, files: ['./...'] });
+                    }
                 })
                 .then(function() {
                     successDirectories.push(dir);
@@ -361,11 +363,13 @@ atomPerforce.exports = {
         function executeRevert() {
             // call p4 info to make sure perforce is available
             return execP4Command('info', { cwd: filepath })
-            .then(function() {
-                return execP4Command('revert', {
-                    cwd: filepath,
-                    files: [path.basename(filename)]
-                });
+            .then(function(p4Info) {
+                if (!p4Info['clientUnknown.'] && filepath.startsWith(p4Info.clientRoot)) {
+                    return execP4Command('revert', {
+                        cwd: filepath,
+                        files: [path.basename(filename)]
+                    });
+                }
             })
             .then(function(result) {
                 if(editor && editor.buffer) {
@@ -431,25 +435,27 @@ atomPerforce.exports = {
 
             // call p4 info to make sure perforce is available
             execP4Command('info', { cwd: openedBufferFilePath })
-            .then(function() {
-                // call p4 diff on the file
-                return execP4Command('diff', {
-                    cwd: openedBufferFilePath,
-                    files: [openedBufferFilename]
-                })
-                .then(function(result) {
-                    console.log(result);
-                    deferred.resolve(processDiff(result));
-                })
-                .catch(function(err) {
-                    if(!/not opened on this client/.test(err)) {
-                        console.error(err);
-                        deferred.reject(err);
-                    }
-                    else {
-                        deferred.resolve([]);
-                    }
-                });
+            .then(function(p4Info) {
+                if (!p4Info['clientUnknown.'] && openedBufferFilePath.startsWith(p4Info.clientRoot)) {
+                                    // call p4 diff on the file
+                    return execP4Command('diff', {
+                        cwd: openedBufferFilePath,
+                        files: [openedBufferFilename]
+                    })
+                    .then(function(result) {
+                        console.log(result);
+                        deferred.resolve(processDiff(result));
+                    })
+                    .catch(function(err) {
+                        if(!/not opened on this client/.test(err)) {
+                            console.error(err);
+                            deferred.reject(err);
+                        }
+                        else {
+                            deferred.resolve([]);
+                        }
+                    });
+                }
             })
             .catch(function(err) {
                 console.error(err);
@@ -528,7 +534,7 @@ atomPerforce.exports = {
             // call p4 info to make sure perforce is available
             execP4Command('info', { cwd: dir })
             .then(function(p4Info) {
-                if(p4Info['clientUnknown.']) {
+                if(p4Info['clientUnknown.'] || dir.startsWith(p4Info.clientRoot)) {
                     setStatusClient(false);
                 }
                 else {
@@ -694,20 +700,23 @@ atomPerforce.exports = {
      */
     fileIsTracked: function fileIsTracked(filepath) {
         var deferred = Q.defer();
-
-        execP4Command('info', { cwd: path.dirname(filepath) })
-        .then(function() {
-            return execP4Command('fstat', {
-                cwd: path.dirname(filepath),
-                files: [path.basename(filepath)]
-            });
-        })
-        .then(function(fileinfo) {
-            if(fileinfo) {
-                deferred.resolve(fileinfo);
-            }
-            else {
-                deferred.resolve(false);
+        var dir = path.dirname(filepath);
+        
+        execP4Command('info', { cwd: dir })
+        .then(function(p4Info) {
+            if (!p4Info['clientUnknown.'] && dir.startsWith(p4Info.clientRoot)) {            
+                return execP4Command('fstat', {
+                    cwd: dir,
+                    files: [path.basename(filepath)]
+                })
+                .then(function(fileinfo) {
+                    if(fileinfo) {
+                        deferred.resolve(fileinfo);
+                    }
+                    else {
+                        deferred.resolve(false);
+                    }
+                });
             }
         })
         .catch(function(err) {


### PR DESCRIPTION
When I try to fix https://github.com/mattsawyer77/atom-perforce/issues/33, I notice some errors that are related to it. Here is the fix for that.

Basically check at various place to see if the filepath/dir is under the clientRoot, if not, they are not in the p4 workspace and all p4 commands will fail with the same `xxx is not under client's root yyy`.
