### PR TITLE
Fix not in client v3

### DIFF
--- a/lib/atom-perforce.js
+++ b/lib/atom-perforce.js
@@ -534,7 +534,7 @@ atomPerforce.exports = {
             // call p4 info to make sure perforce is available
             execP4Command('info', { cwd: dir })
             .then(function(p4Info) {
-                if(p4Info['clientUnknown.'] || p4Info.currentDirectory.startsWith(p4Info.clientRoot)) {
+                if(p4Info['clientUnknown.'] || !p4Info.currentDirectory.startsWith(p4Info.clientRoot)) {
                     setStatusClient(false);
                 }
                 else {


### PR DESCRIPTION
I think it should not show the clientName if the current directory of the current active file is not under the clientRoot.
