### PR TITLE
Diff `not opened for edit` Error

### DIFF
--- a/lib/atom-perforce.js
+++ b/lib/atom-perforce.js
@@ -449,7 +449,7 @@ atomPerforce.exports = {
                         deferred.resolve(processDiff(result));
                     })
                     .catch(function(err) {
-                        if(!/not opened on this client/.test(err)) {
+                        if(!/not opened on this client/.test(err) && !/not opened for edit/.test(err)) {
                             console.error(err);
                             deferred.reject(err);
                         }


### PR DESCRIPTION
Seems to throw that instead of `not opened on client` in windows.
