### PR TITLE
Fix tree decoration based on file status on Windows

### DIFF
--- a/lib/atom-perforce.js
+++ b/lib/atom-perforce.js
@@ -32,6 +32,10 @@ function escapePathSpaces(filepath) {
     }
 }
 
+function escapeBackSlashes(filepath) {
+    return filepath.replace(/\\/g, '\\\\');
+}
+
 function execP4Command(command, options) {
     var p4Fn = p4[command];
     if(p4Fn && p4Fn.call) {
@@ -115,7 +119,7 @@ function transformClientPathToLocalPath(clientPath, p4Info) {
         match = clientPathRegex.exec(clientPath);
 
     if(match) {
-        return p4Info.clientRoot + path.sep + match[1];
+        return path.join(p4Info.clientRoot, match[1]);
     }
     else {
         throw new Error('could not parse client path ', clientPath);
@@ -671,7 +675,7 @@ atomPerforce.exports = {
 
             // add back markers
             p4OpenedFiles.forEach(function(fileinfo) {
-                elements = document.querySelectorAll('[data-path="' + fileinfo.localPath + '"]');
+                elements = document.querySelectorAll('[data-path="' + escapeBackSlashes(fileinfo.localPath) + '"]');
                 [].forEach.call(elements, function(element) {
                     var className;
                     switch(fileinfo.action) {


### PR DESCRIPTION
Crux of the problem is that the data-path of tree nodes has the file path with Windows path separators but the fileinfo.localpath has a mix of Windows and posix/perforce separators.
1. Use `path.join()` in `transformClientPathToLocalPath` to combine clientRoot and the relative path    extracted from the client path. 
2. In `markOpenFiles` escape any backslashes in the selector passed into `querySelectorsAll`.
