### PR TITLE
Add P4CLIENT ENV variable

### DIFF
--- a/lib/atom-perforce.js
+++ b/lib/atom-perforce.js
@@ -14,6 +14,7 @@ var atomPerforce = module, // sugary alias
         .append('<span class="branch-label"></span>'),
     changeHunkDescriptorRegex = /^[\d,]+(\w)(\d+)(,)?(\d+)?$/,
     envVarsToExtract = [
+        'P4CLIENT',
         'P4CONFIG',
         'P4IGNORE',
         'P4PORT',


### PR DESCRIPTION
Add P4CLIENT to list of variables to import from environment. This is useful when user has no .p4config file.
