### PR TITLE
process.env.PATH is now called process.env.Path

### DIFF
--- a/lib/atom-perforce.js
+++ b/lib/atom-perforce.js
@@ -144,10 +144,10 @@ atomPerforce.exports = {
         environmentReady = environment.extractVarsFromEnvironment(envVarsToExtract);
 
         // make sure the default p4 location is in the path
-        pathElements = process.env.PATH.split(path.delimiter);
+        pathElements = process.env.Path.split(path.delimiter);
         if(pathElements.indexOf(defaultPath) === -1) {
             pathElements.unshift(defaultPath);
-            process.env.PATH = pathElements.join(path.delimiter);
+            process.env.Path = pathElements.join(path.delimiter);
         }
         return environmentReady;
     },


### PR DESCRIPTION
This stopped working in 1.7.0 beta. I'm unsure whether the case changed
in 1.7.0 or the name was always supposed to be Path and PATH was only
there as an alias, but the fact is PATH is now undefined and only Path
is there.
