### PR TITLE
adding PATH to the env variable to read

### DIFF
--- a/lib/atom-perforce.js
+++ b/lib/atom-perforce.js
@@ -22,7 +22,8 @@ var atomPerforce = module, // sugary alias
         'P4TICKETS',
         'P4PASSWD',
         'P4CHARSET',
-        'HOME'
+        'HOME',
+        'PATH'
     ],
     clientStatusBarTile,
     environmentReady;


### PR DESCRIPTION
Hi @mattsawyer77 
this PR should fix the issue https://github.com/mattsawyer77/atom-perforce/issues/65.
I've only added the PATH to the list of env vars to extract.

Thank you.
Fabio