### PR TITLE
fix path.dirname must be a string

### DIFF
--- a/lib/atom-perforce.js
+++ b/lib/atom-perforce.js
@@ -552,7 +552,7 @@ atomPerforce.exports = {
         var editor = atom.workspace.getActiveTextEditor(),
             dir;
 
-        if(editor) {
+        if(editor && editor.getPath) {
             dir = path.dirname(editor.getPath());
         }
         else if(atom.project.getDirectories() && atom.project.getDirectories().length) {


### PR DESCRIPTION
This seems to fix following issue #76 